### PR TITLE
Adding stop() error messages.

### DIFF
--- a/R/K2dashboard.R
+++ b/R/K2dashboard.R
@@ -32,32 +32,32 @@ K2dashboard <- function(K2res, analysis_name="K2Taxonomer",
 
     ## K2 algorithm
     if (length(K2results(K2res)) == 0) {
-        "No results found. Please run K2tax() or runK2Taxonomer().\n"
+        stop("No results found. Please run K2tax() or runK2Taxonomer().\n")
     }
 
     ## DGE
     if (is.null(K2results(K2res)[[1]]$dge)) {
-        "No differential analysis results found. Please run runDGEmods().\n"
+        stop("No differential analysis results found. Please run runDGEmods().\n")
     }
 
     ## GSE
     if (is.null(K2results(K2res)[[1]]$gse)) {
-        "No enrichment results found. Please run runDGEmods().\n"
+        stop("No enrichment results found. Please run runDGEmods().\n")
     }
 
     ## GSVA
     if (ncol(K2gSet(K2res)) == 0) {
-        "No ssGSEA data found. Please run runGSVAmods().\n"
+        stop("No ssGSEA data found. Please run runGSVAmods().\n")
     }
 
     ## DSSE
     if (is.null(K2results(K2res)[[1]]$dsse)) {
-        "No differential enrichment results found. Please run runDSSEmods().\n"
+        stop("No differential enrichment results found. Please run runDSSEmods().\n")
     }
 
     ## DSSE
     if (is.null(K2results(K2res)[[1]]$dsse)) {
-        "No differential enrichment results found. Please run runDSSEmods().\n"
+        stop("No differential enrichment results found. Please run runDSSEmods().\n")
     }
 
     ## Create file paths

--- a/R/K2dendro.R
+++ b/R/K2dendro.R
@@ -32,7 +32,7 @@ K2dendro <- function(K2res) {
 
     ## K2 algorithm
     if (length(K2results(K2res)) == 0) {
-        "No results found. Please run K2tax() or runK2Taxonomer().\n"
+        stop("No results found. Please run K2tax() or runK2Taxonomer().\n")
     }
 
     ## Get labels order

--- a/R/K2visNetwork.R
+++ b/R/K2visNetwork.R
@@ -22,7 +22,7 @@ K2visNetwork <- function(K2res) {
 
     ## K2 algorithm
     if (length(K2results(K2res)) == 0) {
-        "No results found. Please run K2tax() or runK2Taxonomer().\n"
+        stop("No results found. Please run K2tax() or runK2Taxonomer().\n")
     }
 
     ## Get results list

--- a/R/runDGEmods.R
+++ b/R/runDGEmods.R
@@ -37,7 +37,7 @@ runDGEmods <- function(K2res) {
 
     ## K2 algorithm
     if (length(K2results(K2res)) == 0) {
-        "No results found. Please run K2tax() or runK2Taxonomer().\n"
+        stop("No results found. Please run K2tax() or runK2Taxonomer().\n")
     }
 
     K2results(K2res) <- lapply(K2results(K2res), function(x) {

--- a/R/runDSSEmods.R
+++ b/R/runDSSEmods.R
@@ -61,22 +61,22 @@ runDSSEmods <- function(K2res) {
 
     ## K2 algorithm
     if (length(K2results(K2res)) == 0) {
-        "No results found. Please run K2tax() or runK2Taxonomer().\n"
+        stop("No results found. Please run K2tax() or runK2Taxonomer().\n")
     }
 
     ## DGE
     if (is.null(K2results(K2res)[[1]]$dge)) {
-        "No differential analysis results found. Please run runDGEmods().\n"
+        stop("No differential analysis results found. Please run runDGEmods().\n")
     }
 
     ## GSE
     if (is.null(K2results(K2res)[[1]]$gse)) {
-        "No enrichment results found. Please run runDGEmods().\n"
+        stop("No enrichment results found. Please run runDGEmods().\n")
     }
 
     ## GSVA
     if (ncol(K2gSet(K2res)) == 0) {
-        "No ssGSEA data found. Please run runGSVAmods().\n"
+        stop("No ssGSEA data found. Please run runGSVAmods().\n")
     }
 
     K2results(K2res) <- lapply(K2results(K2res), function(x) {

--- a/R/runGSEmods.R
+++ b/R/runGSEmods.R
@@ -52,12 +52,12 @@ runGSEmods <- function(K2res, genesets=NULL, qthresh=NULL,
 
     ## K2 algorithm
     if (length(K2results(K2res)) == 0) {
-        "No results found. Please run K2tax() or runK2Taxonomer().\n"
+        stop("No results found. Please run K2tax() or runK2Taxonomer().\n")
     }
 
     ## DGE
     if (is.null(K2results(K2res)[[1]]$dge)) {
-        "No differential analysis results found. Please run runDGEmods().\n"
+        stop("No differential analysis results found. Please run runDGEmods().\n")
     }
 
     ## Change meta data if new value is specific


### PR DESCRIPTION
There's a lot of checks that aren't actually stopping the execution of the function. Just added the stop functionality.
See below for examples!
```
> library(K2Taxonomer)
> library(Biobase)
> data(sample.ExpressionSet)
> K2dashboard(K2res)
Error in K2dashboard(K2res) : 
  No differential analysis results found. Please run runDGEmods().
> runDSSEmods(K2res)
Error in runDSSEmods(K2res) : 
  No differential analysis results found. Please run runDGEmods().
> runGSVAmods(K2res)
Error in .mapGeneSetsToFeatures(gset.idx.list, rownames(expr)) : 
  No identifiers in the gene sets could be matched to the identifiers in the expression data.
In addition: Warning message:
Calling gsva(expr=., gset.idx.list=., method=., ...) is deprecated; use a method-specific parameter object (see '?gsva'). 
```